### PR TITLE
meta-iot-web: Remove bash dependency

### DIFF
--- a/meta-iot-web/recipes-devtools/johnny-five/johnny-five_0.9.59.bb
+++ b/meta-iot-web/recipes-devtools/johnny-five/johnny-five_0.9.59.bb
@@ -9,7 +9,6 @@ S = "${WORKDIR}/npmpkg"
 NPM_LOCKDOWN := "${THISDIR}/${PN}/lockdown.json"
 NPM_SHRINKWRAP := "${THISDIR}/${PN}/npm-shrinkwrap.json"
 DEPENDS += "bash"
-RDEPENDS_johnny-five-serialport-node-pre-gyp-request-node-uuid += "bash"
 
 inherit npm
 

--- a/meta-iot-web/recipes-devtools/nodejs/nodejs_6.11.0.bb
+++ b/meta-iot-web/recipes-devtools/nodejs/nodejs_6.11.0.bb
@@ -103,7 +103,7 @@ pkg_prerm_${PN} () {
 
 PACKAGES =+ "${PN}-npm"
 FILES_${PN}-npm = "${exec_prefix}/lib/node_modules ${bindir}/npm"
-RDEPENDS_${PN}-npm = "bash python-shell python-datetime python-subprocess python-textutils \
+RDEPENDS_${PN}-npm = "python-shell python-datetime python-subprocess python-textutils \
                       python-netclient python-ctypes python-misc python-compiler python-multiprocessing"
 
 PACKAGES =+ "${PN}-systemtap"

--- a/meta-iot-web/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
+++ b/meta-iot-web/recipes-web/iot-rest-api-server/iot-rest-api-server.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=f38da8c6b0e047c28fd0952ad7b59784"
 
 DEPENDS = "nodejs-native iotivity iotivity-node"
-RDEPENDS_${PN} += "bash iotivity-node iptables"
+RDEPENDS_${PN} += "iotivity-node iptables"
 
 SRC_URI = "git://git@github.com/01org/iot-rest-api-server.git;protocol=https \
            file://0001-Remove-iotivity-node-dependency.patch \

--- a/meta-iot-web/recipes-web/iotivity-node/iotivity-node_1.2.1-1.bb
+++ b/meta-iot-web/recipes-web/iotivity-node/iotivity-node_1.2.1-1.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 DEPENDS = "nodejs-native glib-2.0 iotivity"
-RDEPENDS_${PN} += "bash iotivity-resource"
+RDEPENDS_${PN} += "iotivity-resource"
 
 SRC_URI = "git://github.com/otcshare/iotivity-node.git;protocol=https"
 SRCREV = "63587a0d365fc66ec40dc6d4354329d0c1ff092f"


### PR DESCRIPTION
Remove runtime bash dependency from the recipes.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>